### PR TITLE
decorate relarion if decorator_class? true

### DIFF
--- a/lib/draper/simple_form.rb
+++ b/lib/draper/simple_form.rb
@@ -16,7 +16,7 @@ module Draper
         conditions = reflection.options[:conditions]
         conditions = conditions.call if conditions.respond_to?(:call)
         relation = reflection.klass.where(conditions).order(reflection.options[:order])
-        relation = relation.decorate if relation.respond_to?(:decorate)
+        relation = relation.decorate if relation.decorator_class?
         relation
       }
       association_without_decoration association, options, &block


### PR DESCRIPTION
This commit allow use non decorated associations.
It requires development version of draper gem(> 1.2.1).

decorator_class? defined in
https://github.com/drapergem/draper/blob/master/lib/draper/decoratable.rb#L63
