### PR TITLE
decorate relation only if decorator class exists

### DIFF
--- a/lib/draper/simple_form.rb
+++ b/lib/draper/simple_form.rb
@@ -1,5 +1,3 @@
-require 'active_support/concern'
-
 module Draper
   module SimpleFormBuilderExtension
     extend ActiveSupport::Concern
@@ -16,11 +14,11 @@ module Draper
         conditions = reflection.options[:conditions]
         conditions = conditions.call if conditions.respond_to?(:call)
         relation = reflection.klass.where(conditions).order(reflection.options[:order])
-        relation = relation.decorate if relation.respond_to?(:decorate)
-        relation
+        if relation.respond_to?(:decorate) && relation.decorator_class?
+          relation = relation.decorate
+        end
       }
       association_without_decoration association, options, &block
     end
   end
 end
-::SimpleForm::FormBuilder.send :include, Draper::SimpleFormBuilderExtension

--- a/lib/draper/simple_form.rb
+++ b/lib/draper/simple_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'		
+
 module Draper
   module SimpleFormBuilderExtension
     extend ActiveSupport::Concern
@@ -22,3 +24,4 @@ module Draper
     end
   end
 end
+::SimpleForm::FormBuilder.send :include, Draper::SimpleFormBuilderExtension

--- a/lib/draper/simple_form.rb
+++ b/lib/draper/simple_form.rb
@@ -1,4 +1,4 @@
-require 'active_support/concern'		
+require 'active_support/concern'
 
 module Draper
   module SimpleFormBuilderExtension


### PR DESCRIPTION
otherwise throws Draper::UninferrableDecoratorErrors for associations of models without decorator
